### PR TITLE
Adding ForceDynamic

### DIFF
--- a/TED/Simulation.cs
+++ b/TED/Simulation.cs
@@ -61,7 +61,7 @@ namespace TED
         private void FindDynamicPredicates()
         {
             foreach (var t in Tables)
-                t.IsDynamic = false;
+                t.IsDynamic = t.MustBeDynamic;
 
             void MarkDynamic(TablePredicate p)
             {

--- a/TED/TablePredicate.cs
+++ b/TED/TablePredicate.cs
@@ -87,6 +87,15 @@ namespace TED
         public bool IsDynamic { get; internal set; }
 
         /// <summary>
+        /// True if we need the predicate to be dynamic
+        /// </summary>
+        protected internal bool MustBeDynamic;
+        /// <summary>
+        /// Forces a table to be treated as dynamic
+        /// </summary>
+        public void ForceDynamic() => MustBeDynamic = true;
+
+        /// <summary>
         /// True if this table doesn't change during a simulation.
         /// </summary>
         public bool IsStatic => !IsDynamic;


### PR DESCRIPTION
Allows for tables to be dynamic even if they do not have imperative dependencies. Useful when a table is updated by functions and otherwise has not table dependencies.