### PR TITLE
.JointKey and .JointIndexed

### DIFF
--- a/TED/Interpreter/IColumnSpec.cs
+++ b/TED/Interpreter/IColumnSpec.cs
@@ -26,6 +26,9 @@ namespace TED.Interpreter
         /// For general indices, the priority of this index
         /// </summary>
         int? Priority => null;
+
+
+        bool JointPartial => false;
     }
 
     /// <summary>
@@ -59,17 +62,23 @@ namespace TED.Interpreter
 
         public int? Priority => priority;
 
+
+        private readonly bool jointPartial;
+
+        public bool JointPartial => jointPartial;
+
         /// <summary>
         /// Specify information about a column/argument of a table
         /// </summary>
         /// <param name="defaultVariable">Default variable to use</param>
         /// <param name="indexMode">Whether to maintain an index</param>
         /// <param name="priority">Relative priority for using this index in a call versus other indices</param>
-        public IndexedColumnSpec(Var<T> defaultVariable, IndexMode indexMode, int? priority = null)
+        public IndexedColumnSpec(Var<T> defaultVariable, IndexMode indexMode, int? priority = null, bool jointPartial = false)
         {
             variable = defaultVariable;
             IndexMode = indexMode;
             this.priority = priority;
+            this.jointPartial = jointPartial;
         }
 
         public string ColumnName => variable.Name;

--- a/TED/Var.cs
+++ b/TED/Var.cs
@@ -82,6 +82,14 @@ namespace TED
         // ReSharper disable once UnusedMember.Global
         public IColumnSpec<T> IndexPriority(int priority) => new IndexedColumnSpec<T>(this, IndexMode.NonKey, priority);
 
+
+        public IColumnSpec<T> JointKey => new IndexedColumnSpec<T>(this, IndexMode.Key, null, true);
+
+        public IColumnSpec<T> JointIndexed => new IndexedColumnSpec<T>(this, IndexMode.NonKey, null, true);
+
+        public IColumnSpec<T> JointIndexPriority(int priority) => new IndexedColumnSpec<T>(this, IndexMode.NonKey, priority, true);
+
+
         /// <summary>
         /// For variables being used as formal parameters in predicate declarations: whether this column of the table is indexed or not
         /// </summary>


### PR DESCRIPTION
Additional way of denoting which columns should be indexed/keyed on together. Used in the same way as .Key or .Index, TablePredicates now do extra preprocessing to columns to ensure that both regular indices and joint indices are added to the table (Joint indices also add both columns as single column indexes).