### PR TITLE
Fix overwrite link list looping in indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,3 +412,5 @@ FodyWeavers.xsd
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,19 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+*.DS_Store
+
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.TED.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.TED/.idea/.gitignore
+++ b/.idea/.idea.TED/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.TED.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/TED/Tables/GeneralIndex.cs
+++ b/TED/Tables/GeneralIndex.cs
@@ -415,6 +415,10 @@ namespace TED.Tables
         internal override void Clear()
         {
             Array.Fill(buckets!, (default(TColumn), Table.NoRow, 0));
+            Array.Fill(nextRow, Table.NoRow);
+            if (previousRow != null) {
+                Array.Fill(previousRow, Table.NoRow);
+            }
         }
 
         /// <summary>

--- a/TED/Tables/GeneralIndex.cs
+++ b/TED/Tables/GeneralIndex.cs
@@ -320,8 +320,8 @@ namespace TED.Tables
             if (completeDeletions > buckets.Length / 4)
             {
                 Clear();
-                // The length of the table has not yet been incremented, so this won't add the new row yet.
                 Reindex();
+                return; // Reindex calls Add, so we don't want to fall through to Add after finishing reindexing
             }
 
             // Add the new row

--- a/TED/Utilities/UpdateFlowVisualizer.cs
+++ b/TED/Utilities/UpdateFlowVisualizer.cs
@@ -29,7 +29,6 @@ namespace TED.Utilities
                 }
             };
 
-
             g.AddReachableFrom(p.Tables.Where(t => t.IsDynamic), Dependencies);
             return g;
         }


### PR DESCRIPTION
Copied from my last commit message:

"return after reindexing handles an edge case where:
- only one row is in a table,
- that table has a column with a general index,
- the row is overwritten enough times to trigger reindexing (8 times),
- no other rows are added to the table in that time

The last bullet point is more speculative as this is the only thing that I didn't replicate in the repro's for testing. Counter's have worked several times before now and that seems to be the outlier here."

Other than that fix I also made Clear fill the nextRow and previousRow arrays and added Rider files and folders to the gitignore.