### PR TITLE
Fix two linting errors & add rule execution times

### DIFF
--- a/TED/Interpreter/Pattern.cs
+++ b/TED/Interpreter/Pattern.cs
@@ -830,6 +830,7 @@ namespace TED.Interpreter
         /// Write the values from the pattern out to a row in a table after a successful match
         /// </summary>
         public void Write(out (T1, T2, T3, T4, T5, T6, T7, T8) target) {
+            target = (default, default, default, default, default, default, default, default)!;
             Arg1.Write(out target.Item1);
             Arg2.Write(out target.Item2);
             Arg3.Write(out target.Item3);

--- a/TED/TablePredicate.cs
+++ b/TED/TablePredicate.cs
@@ -363,6 +363,10 @@ namespace TED {
         /// Combined average execution time of all the rules for this predicate.
         /// </summary>
         public float RuleExecutionTime => Rules == null?0:Rules.Select(r => r.AverageExecutionTime).Sum();
+        /// <summary>
+        /// Combined average execution time for each rule (regardless of predicate).
+        /// </summary>
+        public IEnumerable<(Rule, float)> RuleExecutionTimes => Rules == null? Array.Empty<(Rule, float)>():Rules.Select(r => (r, r.AverageExecutionTime));
         #endif
 
         /// <summary>
@@ -4800,9 +4804,7 @@ namespace TED {
                 4 => (Func<uint, TColumn>)(Delegate)(Func<uint,T5>)(rowNum => _table.Data[rowNum].Item5),
                 5 => (Func<uint, TColumn>)(Delegate)(Func<uint,T6>)(rowNum => _table.Data[rowNum].Item6),
                 6 => (Func<uint, TColumn>)(Delegate)(Func<uint,T7>)(rowNum => _table.Data[rowNum].Item7),
-                // VS says there's a type error here because it thinks Item8 returns T1 rather than T8
-                // but the code compiles fine.
-                7 => (Func<uint, TColumn>)(Delegate)(Func<uint,T8>)(rowNum => _table.Data[rowNum].Item8),
+                7 => (Func<uint, TColumn>)(Delegate)(Func<uint,T8>)(rowNum => _table.Data[rowNum].Rest.Item1),
                 _ => throw new ArgumentException($"There is no column number {columnNumber} in table {Name}")
             };
         }


### PR DESCRIPTION
Octuples are implemented kinda funny - Tuple<T1,T2,T3,T4,T5,T6,T7,TRest> where TRest is a generic Tuple object which contains the values of the tuple’s remaining components... Using Item8 still works in some places but for the ColumnValueFromRowNumber delegate switch statement we need to use the Rest.Item1 paradigm (I believe because of our use of generics).

In pattern, setting defaults before doing the arg.write out calls should only give defaults if the argument writing fails. This error only shows up in the octuple version and I think this is again because of the TRest implementation (but I haven't verified that).

Rule Execution times shows average time for each rule (not grouped by table). [closes Rule Execution Times #30]